### PR TITLE
Prevent crash after getting a gameover in a level with a toad.

### DIFF
--- a/src/engine/behavior_script.c
+++ b/src/engine/behavior_script.c
@@ -412,7 +412,7 @@ static s32 bhv_cmd_randomize_object(void) {
                 gCurBhvCommand++;
                 return BHV_PROC_CONTINUE;
             }
-        } else if (gCurrentObject->behavior == segmented_to_virtual(bhvRedCoin)) {
+        } else if (gCurrentObject->behavior == segmented_to_virtual(bhvRedCoin) && gCurrLevelNum != LEVEL_SA) {
             f32 rand = tinymt32_generate_float(&randomState);
             f32 chance = gOptionsSettings.gameplay.s.safeSpawns == SPAWN_SAFETY_HARD ? (1 / 50.f) : (1 / 200.f);
             if (HARDCORE_IRONMARIO) chance = (1/25.f); // double chance

--- a/src/game/area.c
+++ b/src/game/area.c
@@ -249,7 +249,7 @@ void load_area(s32 index) {
 
         if (gCurrentArea->objectSpawnInfos != NULL) {
             spawn_objects_from_info(0, gCurrentArea->objectSpawnInfos);
-            if (gCurrentArea->objectSpawnInfos[0].behaviorScript != bhvActSelector) {
+            if (gCurrentArea->objectSpawnInfos[0].behaviorScript != bhvActSelector && gCurrentArea->objectSpawnInfos[0].behaviorScript != bhvYellowBackgroundInMenu) {
                 spawn_toads();
             }
         }


### PR DESCRIPTION
When it runs the `loadArea` code for file select, `gCurrLevelNum` is still set to whatever level you were in when you get game over. I'm not sure why the first object in the list isn't `bhvMenuButtonManager`, I'm just going by what i see in the debugger.